### PR TITLE
Intercept and replace origin in HTTP requests

### DIFF
--- a/.github/workflows/release-rancher-desktop.yml
+++ b/.github/workflows/release-rancher-desktop.yml
@@ -9,8 +9,8 @@ env:
   OUTPUT_DIR: dist
   RELEASE_DIR: release
   ARTIFACT_NAME: rancher-dashboard-desktop-embed
-  API: "https://127.0.0.1:9443"
-  RESOURCE_BASE: "https://127.0.0.1:9443"
+  API: "https://127.0.0.1:6120"
+  RESOURCE_BASE: "https://127.0.0.1:6120"
   
 jobs:
   build:
@@ -27,7 +27,7 @@ jobs:
     
     - name: Install & Build
       run:
-        ROUTER_BASE="/dashboard" RANCHER_ENV=desktop ./.github/workflows/scripts/build-dashboard.sh
+        RANCHER_ENV=desktop ./.github/workflows/scripts/build-dashboard.sh
 
     - name: Upload Build
       uses: actions/upload-artifact@v2

--- a/shell/plugins/axios.js
+++ b/shell/plugins/axios.js
@@ -4,7 +4,7 @@ import { parse as setCookieParser } from 'set-cookie-parser';
 import pkg from '../package.json';
 
 export default function({
-  $axios, $cookies, isDev, req
+  $axios, $cookies, $config, isDev, req
 }) {
   $axios.defaults.headers.common['Accept'] = 'application/json';
   $axios.defaults.withCredentials = true;
@@ -63,5 +63,18 @@ export default function({
 
     $axios.defaults.httpsAgent = insecureAgent;
     $axios.httpsAgent = insecureAgent;
+  }
+
+  if ($config.rancherEnv === 'desktop') {
+    $axios.interceptors.request.use((config) => {
+      if (!config.url.startsWith('http')) {
+        return config;
+      }
+
+      const url = new URL(config.url);
+      const urlTrimmed = config.url.replace(`${ url.origin }`, '');
+
+      return { ...config, url: urlTrimmed };
+    });
   }
 }


### PR DESCRIPTION
This intercepts and replaces the origin of all HTTP requests that start with `http` in Rancher Desktop builds of Rancher Dashboard. We need to do this in order to accommodate plugins work for Rancher Desktop by running a local server that proxies all requests to Steve. By intercepting and trimming the route, we can make sure that all URLs adhere to a similar structure (e.g. `/v1/userpreferences`) so that they are proxy-able by Rancher Desktop's web server. 

The logic that we are attempting to correct with this PR:

* When `findAll` for `counts` and `namespaces` is invoked without `opt`, that acts as a prompt to to get the URL for the endpoint from the corresponding schema via `links => collection`. This is how we end up with the Steve URL (`https://127.0.0.1:9443/v1/counts`)
* `findAll` for other resources that contain `opt` have a `url` formatted as a relative route (`/v1/userpreferences`)
* Just because `findAll` is invoked with `opt` once, doesn't mean that it will always contain `opt` for other requests. For example, I've observed `provisioning.cattle.io.cluster`  displaying both behaviors described in items 1 & 2 above

contributes to rancher-sandbox/rancher-desktop#2825